### PR TITLE
Add the name to the anchor and force to open in new window/tab.

### DIFF
--- a/hostext/hooks/addhostexthost.hook.php
+++ b/hostext/hooks/addhostexthost.hook.php
@@ -108,9 +108,11 @@ class AddHostextHost extends Hook
             } else {
                 $inputstr = str_replace('${{REPL}}', $obj->get($item->variable), $inputstr);
             }
-            $inputstr .= '"><i class="icon fa fa-external-link" title="';
+            $inputstr .= '" target="_blank"><i class="icon fa fa-external-link" title="';
             $inputstr .= $item->name;
-            $inputstr .= '"></i></a>';
+            $inputstr .= '"></i> ';
+            $inputstr .= $item->name;
+            $intputstr .= '</a>';
             $fields = [
                 FOGPage::makeLabel(
                     'col-sm-3 control-label',


### PR DESCRIPTION
As the commit message suggests.

This adds a target="_blank" and appends the name of the external request to make it more explicit on what it's doing.